### PR TITLE
fix: use head_bucket instead of get_bucket_location for bucket info

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,33 @@
 PATH
   remote: .
   specs:
-    uri_s3 (0.1.1)
+    uri_s3 (0.2.1)
       aws-sdk-s3 (~> 1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-eventstream (1.1.0)
-    aws-partitions (1.310.0)
-    aws-sdk-core (3.94.1)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.239.0)
-      aws-sigv4 (~> 1.1)
-      jmespath (~> 1.0)
-    aws-sdk-kms (1.30.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.63.1)
-      aws-sdk-core (~> 3, >= 3.83.0)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.1033.0)
+    aws-sdk-core (3.214.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.96.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.177.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.3)
-      aws-eventstream (~> 1.0, >= 1.0.2)
-    jmespath (1.4.0)
-    rake (13.0.1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.10.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    jmespath (1.6.2)
+    rake (13.2.1)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -35,4 +36,4 @@ DEPENDENCIES
   uri_s3!
 
 BUNDLED WITH
-   2.0.1
+   2.5.23

--- a/lib/uri/s3.rb
+++ b/lib/uri/s3.rb
@@ -14,7 +14,7 @@ module URI
 
     def s3_region
       @s3_region ||= begin
-                       region = Aws::S3::Client.new.get_bucket_location(bucket: host).location_constraint
+                       region = Aws::S3::Client.new.head_bucket(bucket: host).bucket_region
                        if region.empty?
                          "us-east-1"
                        else

--- a/lib/uri_s3/version.rb
+++ b/lib/uri_s3/version.rb
@@ -1,3 +1,3 @@
 module S3Uri
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
The S3 api changed so that `get_bucket_location` fails when it's not called from the region where the bucket lives, making it useless for actually getting the bucket location.

This switches to invoking `head_bucket`, which _is_ allowed for cross-region calls (though it logs a warning in the console), which should fix the problem.